### PR TITLE
Fix crash when annexing kingdom's leader becomes part of annexed kingdom

### DIFF
--- a/DestroyKingdom/Actions/KingdomAnnexationAction.cs
+++ b/DestroyKingdom/Actions/KingdomAnnexationAction.cs
@@ -20,6 +20,7 @@ internal static class KingdomAnnexationAction
 
     public static void Apply(Kingdom annexedKingdom, Kingdom annexingKingdom, bool showNotification = true)
     {
+        var annexingLeader = annexingKingdom.Leader;
         List<Clan> annexedClans = new(annexedKingdom.Clans);
         foreach (var clan in annexedClans)
         {
@@ -47,7 +48,10 @@ internal static class KingdomAnnexationAction
             MakePeaceAction.Apply(annexedKingdom, annexingKingdom);
         }
 
-        DestroyKingdomAction.Apply(annexedKingdom);
-        annexedKingdom.RulingClan = annexingKingdom.RulingClan;
+        if (annexingLeader?.Clan?.Kingdom != annexedKingdom)
+        {
+            DestroyKingdomAction.Apply(annexedKingdom);
+            annexedKingdom.RulingClan = annexingKingdom.RulingClan;
+        }
     }
 }

--- a/DestroyKingdom/DestroyKingdom.csproj
+++ b/DestroyKingdom/DestroyKingdom.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Bannerlord.BUTRModule.Sdk/1.0.1.80">
 
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <TargetFramework>net472</TargetFramework>
     <Platforms>x64</Platforms>
     <LangVersion>10.0</LangVersion>


### PR DESCRIPTION
This happens after making peace during civil war feature of Diplomacy mod.

- Annexation mod is making peace between rebel faction and parent kingdom when rebel faction is annexing parent kingdom
- After making peace with your parent kingdom you're becoming part of that kingdom again - this is triggered by Diplomacy mod
- Next action of Annexation mod is to destroy kingdom that you're about to annexate - but at this point you're already part of this kingdom since Diplomacy removed your rebel kingdom and your demands have been satisfied
- Destroying a kingdom which still has some clans results in destroying those clans and killings all their characters - including you and this eventually leads to a crash

Reported here:
https://steamcommunity.com/workshop/filedetails/discussion/2890216380/3596716230217848024/#c3596716230219693217
And probably here as well:
https://steamcommunity.com/workshop/filedetails/discussion/2890216380/3596716230227315274/