### PR TITLE
0.3.1: Vassalization of rebels cheats

### DIFF
--- a/DestroyKingdom/Cheats.cs
+++ b/DestroyKingdom/Cheats.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+using DestroyKingdom.Data;
+using DestroyKingdom.Extensions;
+using JetBrains.Annotations;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+
+namespace DestroyKingdom;
+
+public class Cheats
+{
+    private const string VassalizeAllRebelsInfo =
+        "You need to provide kingdom name as a parameter (spaces are ignored): 'annexation.vassalize_all_rebels [kingdom]'.";
+
+    private const string VassalizeClanInfo =
+        "You need to provide kingdom name and clan name as a parameters (spaces are ignored): 'annexation.vassalize_clan [kingdom] [clan]'.";
+
+    [CommandLineFunctionality.CommandLineArgumentFunction("vassalize_all_rebels", "annexation")]
+    [UsedImplicitly]
+    public static string VassalizeAllRebels(List<string> strings)
+    {
+        if (strings.IsEmpty())
+        {
+            return VassalizeAllRebelsInfo;
+        }
+
+        var kingdom = KingdomExtensions.AllActiveKingdomsFactions().Find(kingdom =>
+            kingdom.Name.ToString().ToLower().Replace(" ", "") == strings[0]
+        );
+        if (kingdom == null)
+        {
+            return $"Couldn't find kingdom with {strings[0]} name. {VassalizeAllRebelsInfo}";
+        }
+
+        var kingdomlessClans =
+            Clan.All.Where(clan =>
+                    !clan.IsEliminated &&
+                    AnnexationRebelClansStorage.Instance?.IsRebelClanAgainstAnnexingKingdom(clan, kingdom) == true
+                )
+                .ToList();
+        foreach (var clan in kingdomlessClans)
+        {
+            MakePeaceAction.Apply(clan, kingdom);
+            ChangeKingdomAction.ApplyByJoinToKingdom(clan, kingdom);
+        }
+
+        return $"{kingdomlessClans.Count} clans without kingdom joined {kingdom.Name}.";
+    }
+
+    [CommandLineFunctionality.CommandLineArgumentFunction("vassalize_clan", "annexation")]
+    [UsedImplicitly]
+    public static string VassalizeClan(List<string> strings)
+    {
+        if (strings.Count < 2)
+        {
+            return VassalizeClanInfo;
+        }
+
+        var kingdom = KingdomExtensions.AllActiveKingdomsFactions().Find(kingdom =>
+            kingdom.Name.ToString().ToLower().Replace(" ", "") == strings[0]
+        );
+        if (kingdom == null)
+        {
+            return $"Couldn't find kingdom with {strings[0]} name. {VassalizeClanInfo}";
+        }
+
+        var clan = Clan.All.ToList().Find(clan =>
+            clan.Name.ToString().ToLower().Replace(" ", "") == strings[1]
+        );
+        if (clan == null)
+        {
+            return $"Couldn't find clan with {strings[1]} name. {VassalizeClanInfo}";
+        }
+
+        MakePeaceAction.Apply(clan, kingdom);
+        ChangeKingdomAction.ApplyByJoinToKingdom(clan, kingdom);
+        return $"{clan.Name} clan joined {kingdom.Name}.";
+    }
+}

--- a/DestroyKingdom/DestroyKingdom.csproj
+++ b/DestroyKingdom/DestroyKingdom.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Bannerlord.BUTRModule.Sdk/1.0.1.80">
 
   <PropertyGroup>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <TargetFramework>net472</TargetFramework>
     <Platforms>x64</Platforms>
     <LangVersion>10.0</LangVersion>


### PR DESCRIPTION
Cheats that will help you to revassalize rebel clans if you don't want this behavior and you have overriden previous save files.

annexation.vassalize_all_rebels [kingdom] - all rebel clans against given kingdom (only applies to annexation related rebels) will make peace with this kingdom and join it as vassals (e.g. annexation.vassalize_all_rebels northernempire).

annexation.vassalize_clan [kingdom] [clan] - given clan will join given kingdom (e.g. annexation.vassalize_clan northernempire julios).

If you have saved your game with Annexation mod disabled since annexation happened, game doesn't know which clans are rebels as saving the game without mod erased all mod's data. In that case enable mod again and use vassalize_clan command for each rebel clan (you can find them in encyclopedia after opening list of clans and filtering for cnemy clans. Some of them might not be related to annexation (e.g. city rebellion), but from there you should be able to realize which ones you want to fix.

If you don't want to use rebels mechanics please set minimum collaboration chance to 100% in Mod Options menu - all clans of annexed kingdom will join annexing kingdom in that case.